### PR TITLE
Fix most of golangci-lint errors in the pixiecore package

### DIFF
--- a/pixiecore/booters.go
+++ b/pixiecore/booters.go
@@ -257,7 +257,7 @@ func (b *apibooter) ReadBootFile(id ID) (io.ReadCloser, int64, error) {
 	}
 	var (
 		ret io.ReadCloser
-		sz  int64 = -1
+		sz  int64
 	)
 	if u.Scheme == "file" {
 		// TODO serveFile
@@ -284,9 +284,9 @@ func (b *apibooter) ReadBootFile(id ID) (io.ReadCloser, int64, error) {
 		}
 
 		ret, sz, err = resp.Body, resp.ContentLength, nil
-	}
-	if err != nil {
-		return nil, -1, err
+		if err != nil {
+			return nil, -1, err
+		}
 	}
 	return ret, sz, nil
 }

--- a/pixiecore/cli/bootipv6cmd.go
+++ b/pixiecore/cli/bootipv6cmd.go
@@ -2,12 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"go.universe.tf/netboot/dhcp6"
 	"go.universe.tf/netboot/dhcp6/pool"
 	"go.universe.tf/netboot/pixiecore"
-	"net"
-	"strings"
 )
 
 // pixiecore bootipv6 --listen-addr=2001:db8:f00f:cafe::4/64 --httpboot-url=http://[2001:db8:f00f:cafe::4]/bootx64.efi --ipxe-url=http://[2001:db8:f00f:cafe::4]/script.ipxe
@@ -41,7 +42,6 @@ var bootIPv6Cmd = &cobra.Command{
 
 		if addr == "" {
 			fatalf("Please specify address to bind to")
-		} else {
 		}
 		if ipxeURL == "" {
 			fatalf("Please specify ipxe config file url")

--- a/pixiecore/cli/ipv6apicmd.go
+++ b/pixiecore/cli/ipv6apicmd.go
@@ -2,13 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"net"
+	"strings"
+	"time"
+
 	"github.com/spf13/cobra"
 	"go.universe.tf/netboot/dhcp6"
 	"go.universe.tf/netboot/dhcp6/pool"
 	"go.universe.tf/netboot/pixiecore"
-	"net"
-	"strings"
-	"time"
 )
 
 // pixiecore ipv6api --listen-addr=2001:db8:f00f:cafe::4  --api-request-url=http://[2001:db8:f00f:cafe::4]:8888
@@ -42,7 +43,6 @@ var ipv6ApiCmd = &cobra.Command{
 
 		if addr == "" {
 			fatalf("Please specify address to bind to")
-		} else {
 		}
 		if apiURL == "" {
 			fatalf("Please specify ipxe config file url")

--- a/pixiecore/http_test.go
+++ b/pixiecore/http_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 )
 
@@ -33,8 +32,6 @@ func (b booterFunc) ReadBootFile(id ID) (io.ReadCloser, int64, error) {
 	return nil, -1, errors.New("no")
 }
 func (b booterFunc) WriteBootFile(id ID, r io.Reader) error { return errors.New("no") }
-
-var logSync sync.Mutex
 
 func TestIpxe(t *testing.T) {
 	booter := func(m Machine) (*Spec, error) {

--- a/pixiecore/tftp.go
+++ b/pixiecore/tftp.go
@@ -60,12 +60,11 @@ func extractInfo(path string) (net.HardwareAddr, int, error) {
 }
 
 func (s *Server) logTFTPTransfer(clientAddr net.Addr, path string, err error) {
-	mac, _, err := extractInfo(path)
-	if err != nil {
-		// Unknown path, nothing to log.
+	mac, _, pathErr := extractInfo(path)
+	if pathErr != nil {
+		s.log("TFTP", "unable to extract mac from request:%v", pathErr)
 		return
 	}
-
 	if err != nil {
 		s.log("TFTP", "Send of %q to %s failed: %s", path, clientAddr, err)
 	} else {


### PR DESCRIPTION
Hi @danderson 

just stumbled over some golangci-lint issues in the pixiecore package, if you are interested please consider merging.

```
golangci-lint run |grep pixiecore
pixiecore/api-example/main.go:39:21: Error return value of `http.ListenAndServe` is not checked (errcheck)
pixiecore/boot_configuration.go:98:14: Error return value of `buf.ReadFrom` is not checked (errcheck)
pixiecore/booters_test.go:154:15: Error return value of `http.Serve` is not checked (errcheck)
pixiecore/cli/cli.go:86:24: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkHidden` is not checked (errcheck)
pixiecore/http_test.go:37:5: `logSync` is unused (varcheck)
pixiecore/booters.go:260:3: ineffectual assignment to `sz` (ineffassign)
pixiecore/booters.go:286:12: ineffectual assignment to `err` (ineffassign)
pixiecore/booters.go:288:9: nilness: impossible condition: nil != nil (govet)
pixiecore/tftp.go:69:9: nilness: impossible condition: nil != nil (govet)
pixiecore/cli/bootipv6cmd.go:44:10: SA9003: empty branch (staticcheck)
pixiecore/cli/ipv6apicmd.go:45:10: SA9003: empty branch (staticcheck)
pixiecore/logging.go:104:18: U1000: func `(*Server).debugPacket` is unused (unused)
pixiecore/tftp.go:62:68: SA4009: argument err is overwritten before first use (staticcheck)
```