### PR TITLE
fix architecture types 7 and 9

### DIFF
--- a/pixiecore/dhcp.go
+++ b/pixiecore/dhcp.go
@@ -111,10 +111,10 @@ func (s *Server) validateDHCP(pkt *dhcp4.Packet) (mach Machine, fwtype Firmware,
 		fwtype = FirmwareEFI32
 	case 7:
 		mach.Arch = ArchX64
-		fwtype = FirmwareEFI64
+		fwtype = FirmwareEFIBC
 	case 9:
 		mach.Arch = ArchX64
-		fwtype = FirmwareEFIBC
+		fwtype = FirmwareEFI64
 	default:
 		return mach, 0, fmt.Errorf("unsupported client firmware type '%d' (please file a bug!)", fwtype)
 	}

--- a/pixiecore/pxe.go
+++ b/pixiecore/pxe.go
@@ -100,9 +100,9 @@ func (s *Server) validatePXE(pkt *dhcp4.Packet) (fwtype Firmware, err error) {
 	case 6:
 		fwtype = FirmwareEFI32
 	case 7:
-		fwtype = FirmwareEFI64
-	case 9:
 		fwtype = FirmwareEFIBC
+	case 9:
+		fwtype = FirmwareEFI64
 	default:
 		return 0, fmt.Errorf("unsupported client firmware type '%d' (please file a bug!)", fwt)
 	}


### PR DESCRIPTION
> As of the writing of this document, the following pre-boot architecture types
> have been requested.
>
> Type   Architecture Name
> ----   -----------------
> 0    Intel x86PC
> 1    NEC/PC98
> 2    EFI Itanium
> 3    DEC Alpha
> 4    Arc x86
> 5    Intel Lean Client
> 6    EFI IA32
> 7    EFI BC
> 8    EFI Xscale
> 9    EFI x86-64

-- https://tools.ietf.org/html/rfc4578#section-2.1