### PR TITLE
Use udp4 instead of udp

### DIFF
--- a/pixiecore/pixiecore.go
+++ b/pixiecore/pixiecore.go
@@ -227,7 +227,7 @@ func (s *Server) Serve() error {
 		dhcp.Close()
 		return err
 	}
-	pxe, err := net.ListenPacket("udp", fmt.Sprintf("%s:%d", s.Address, s.PXEPort))
+	pxe, err := net.ListenPacket("udp4", fmt.Sprintf("%s:%d", s.Address, s.PXEPort))
 	if err != nil {
 		dhcp.Close()
 		tftp.Close()


### PR DESCRIPTION
fix interface metadata errors for MacOS

Fixes #104