### PR TITLE
quickcmd: Ubuntu version up to focal

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -90,11 +90,12 @@ func ubuntuRecipe(parent *cobra.Command) {
 	versions := []string{
 		"precise",
 		"trusty",
-		"vivid",
-		"wily",
 		"xenial",
-		"yakkety",
-		"zesty",
+		"bionic",
+		"cosmic",
+		"disco",
+		"eoan",
+		"focal",
 	}
 
 	ubuntuCmd := &cobra.Command{


### PR DESCRIPTION
Removes old versions no longer present on http://mirrors.edge.kernel.org/ubuntu/dists/