### PR TITLE
work around broken ipxe EMBED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ci-config:
 
 .PHONY: update-ipxe
 update-ipxe:
-	EMBED=$(HERE)/pixiecore/boot.ipxe \
+	EMBEDDED_IMAGE=$(HERE)/pixiecore/boot.ipxe \
 	$(MAKE) -C third_party/ipxe/src \
 	bin/ipxe.pxe \
 	bin/undionly.kpxe \


### PR DESCRIPTION
The `EMBED` option on (at least) the latest ipxe release is broken --- one of its Makefiles eagerly assigns over that variable when it should only be doing so when it's undefined and/or empty. As of this writing, I have an open PR that fixes this issue:

https://github.com/ipxe/ipxe/pull/115

Fortunately, the ipxe developers left a variable in for backward compatibility that we can use instead; i.e., `EMBEDDED_IMAGE`.