### PR TITLE
trivial: silent most golang-ci-lint errors in production code

### DIFF
--- a/dhcp4/options.go
+++ b/dhcp4/options.go
@@ -164,15 +164,27 @@ func (o Options) marshalLimited(w io.Writer, nBytes int, skip52 bool) (Options, 
 			continue
 		}
 
-		w.Write([]byte{byte(n), byte(len(opt))})
-		w.Write(opt)
+		_, err := w.Write([]byte{byte(n), byte(len(opt))})
+		if err != nil {
+			return nil, err
+		}
+		_, err = w.Write(opt)
+		if err != nil {
+			return nil, err
+		}
 		nBytes -= len(opt) + 2
 	}
 
-	w.Write([]byte{255})
+	_, err := w.Write([]byte{255})
+	if err != nil {
+		return nil, err
+	}
 	nBytes--
 	if nBytes > 0 {
-		w.Write(make([]byte, nBytes))
+		_, err = w.Write(make([]byte, nBytes))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return ret, nil

--- a/dhcp4/packet.go
+++ b/dhcp4/packet.go
@@ -187,10 +187,22 @@ func (p *Packet) Marshal() ([]byte, error) {
 		ret.Write([]byte{0, 0})
 	}
 
-	writeIP(ret, p.ClientAddr)
-	writeIP(ret, p.YourAddr)
-	writeIP(ret, p.ServerAddr)
-	writeIP(ret, p.RelayAddr)
+	err = writeIP(ret, p.ClientAddr)
+	if err != nil {
+		return nil, err
+	}
+	err = writeIP(ret, p.YourAddr)
+	if err != nil {
+		return nil, err
+	}
+	err = writeIP(ret, p.ServerAddr)
+	if err != nil {
+		return nil, err
+	}
+	err = writeIP(ret, p.RelayAddr)
+	if err != nil {
+		return nil, err
+	}
 
 	// MAC address + 10 bytes of padding
 	ret.Write([]byte(p.HardwareAddr))
@@ -237,12 +249,14 @@ func (p *Packet) Marshal() ([]byte, error) {
 	return ret.Bytes(), nil
 }
 
-func writeIP(w io.Writer, ip net.IP) {
+func writeIP(w io.Writer, ip net.IP) error {
 	ip = ip.To4()
 	if ip == nil {
-		w.Write([]byte{0, 0, 0, 0})
+		_, err := w.Write([]byte{0, 0, 0, 0})
+		return err
 	} else {
-		w.Write([]byte(ip))
+		_, err := w.Write([]byte(ip))
+		return err
 	}
 }
 

--- a/dhcp6/packet.go
+++ b/dhcp6/packet.go
@@ -50,7 +50,7 @@ func (p *Packet) Marshal() ([]byte, error) {
 		return nil, fmt.Errorf("packet has malformed options section: %s", err)
 	}
 
-	ret := make([]byte, len(marshalledOptions)+4, len(marshalledOptions)+4)
+	ret := make([]byte, len(marshalledOptions)+4)
 	ret[0] = byte(p.Type)
 	copy(ret[1:], p.TransactionID[:])
 	copy(ret[4:], marshalledOptions)
@@ -99,7 +99,7 @@ func shouldDiscardRequest(p *Packet, serverDuid []byte) error {
 	if !options.HasServerID() {
 		return fmt.Errorf("'Request' packet has no server id option")
 	}
-	if bytes.Compare(options.ServerID(), serverDuid) != 0 {
+	if !bytes.Equal(options.ServerID(), serverDuid) {
 		return fmt.Errorf("'Request' packet's server id option (%d) is different from ours (%d)", options.ServerID(), serverDuid)
 	}
 	return nil
@@ -113,7 +113,7 @@ func shouldDiscardInformationRequest(p *Packet, serverDuid []byte) error {
 	if options.HasIaNa() || options.HasIaTa() {
 		return fmt.Errorf("'Information-request' packet has an IA option present")
 	}
-	if options.HasServerID() && (bytes.Compare(options.ServerID(), serverDuid) != 0) {
+	if options.HasServerID() && (!bytes.Equal(options.ServerID(), serverDuid)) {
 		return fmt.Errorf("'Information-request' packet's server id option (%d) is different from ours (%d)", options.ServerID(), serverDuid)
 	}
 	return nil

--- a/dhcp6/packet_builder.go
+++ b/dhcp6/packet_builder.go
@@ -123,7 +123,7 @@ func (b *PacketBuilder) makeMsgReleaseReply(transactionID [3]byte, serverDUID, c
 
 	retOptions.Add(MakeOption(OptClientID, clientID))
 	retOptions.Add(MakeOption(OptServerID, serverDUID))
-	v := make([]byte, 19, 19)
+	v := make([]byte, 19)
 	copy(v[2:], []byte("Release received."))
 	retOptions.Add(MakeOption(OptStatusCode, v))
 
@@ -177,6 +177,6 @@ func iasWithoutAddesses(availableAssociations []*IdentityAssociation, allIAs [][
 
 func calculateIAIDHash(interfaceID []byte) uint64 {
 	h := fnv.New64a()
-	h.Write(interfaceID)
+	_, _ = h.Write(interfaceID)
 	return h.Sum64()
 }

--- a/dhcp6/pool/random_address_pool.go
+++ b/dhcp6/pool/random_address_pool.go
@@ -2,13 +2,14 @@ package pool
 
 import (
 	"fmt"
-	"go.universe.tf/netboot/dhcp6"
 	"hash/fnv"
 	"math/big"
 	"math/rand"
 	"net"
 	"sync"
 	"time"
+
+	"go.universe.tf/netboot/dhcp6"
 )
 
 type associationExpiration struct {
@@ -153,7 +154,7 @@ func (p *RandomAddressPool) calculateAssociationExpiration(now time.Time) time.T
 
 func (p *RandomAddressPool) calculateIAIDHash(clientID, interfaceID []byte) uint64 {
 	h := fnv.New64a()
-	h.Write(clientID)
-	h.Write(interfaceID)
+	_, _ = h.Write(clientID)
+	_, _ = h.Write(interfaceID)
 	return h.Sum64()
 }

--- a/pixiecore/api-example/main.go
+++ b/pixiecore/api-example/main.go
@@ -36,7 +36,10 @@ var (
 func main() {
 	flag.Parse()
 	http.HandleFunc("/v1/boot/", api)
-	http.ListenAndServe(":"+strconv.Itoa(*port), nil)
+	err := http.ListenAndServe(":"+strconv.Itoa(*port), nil)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func api(w http.ResponseWriter, r *http.Request) {

--- a/pixiecore/boot_configuration.go
+++ b/pixiecore/boot_configuration.go
@@ -95,7 +95,10 @@ func (bc *APIBootConfiguration) GetBootURL(id []byte, clientArchType uint16) ([]
 	defer resp.Body.Close()
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
+	_, err = buf.ReadFrom(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	url, _ := bc.makeURLAbsolute(buf.String())
 
 	return []byte(url), nil

--- a/pixiecore/cli/cli.go
+++ b/pixiecore/cli/cli.go
@@ -83,7 +83,10 @@ func serverConfigFlags(cmd *cobra.Command) {
 
 	// Development flags, hidden from normal use.
 	cmd.Flags().String("ui-assets-dir", "", "UI assets directory (used for development)")
-	cmd.Flags().MarkHidden("ui-assets-dir")
+	err := cmd.Flags().MarkHidden("ui-assets-dir")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func mustFile(path string) []byte {

--- a/pixiecore/dhcpv6.go
+++ b/pixiecore/dhcpv6.go
@@ -2,6 +2,7 @@ package pixiecore
 
 import (
 	"fmt"
+
 	"go.universe.tf/netboot/dhcp6"
 )
 
@@ -23,10 +24,10 @@ func (s *ServerV6) serveDHCP(conn *dhcp6.Conn) error {
 		if err != nil {
 			s.log("dhcpv6", fmt.Sprintf("Error creating response for transaction: %d: %s", pkt.TransactionID, err))
 			if response == nil {
-				s.log("dhcpv6", fmt.Sprintf("Dropping the packet"))
+				s.log("dhcpv6", "Dropping the packet")
 				continue
 			} else {
-				s.log("dhcpv6", fmt.Sprintf("Will notify the client"))
+				s.log("dhcpv6", "Will notify the client")
 			}
 		}
 		if response == nil {

--- a/pixiecore/http.go
+++ b/pixiecore/http.go
@@ -113,7 +113,10 @@ func (s *Server) handleIpxe(w http.ResponseWriter, r *http.Request) {
 	start = time.Now()
 	s.machineEvent(mac, machineStateIpxeScript, "Sent iPXE boot script")
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(script)
+	_, err = w.Write(script)
+	if err != nil {
+		s.debug("HTTP", "writing response caused an error:%v", err)
+	}
 	s.debug("HTTP", "Writing ipxe script to %s took %s", mac, time.Since(start))
 	s.debug("HTTP", "handleIpxe for %s took %s", mac, time.Since(overallStart))
 }

--- a/pixiecore/logging.go
+++ b/pixiecore/logging.go
@@ -15,7 +15,6 @@
 package pixiecore
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net"
 	"time"
@@ -99,11 +98,4 @@ func (s *Server) debug(subsystem, format string, args ...interface{}) {
 		return
 	}
 	s.Debug(subsystem, fmt.Sprintf(format, args...))
-}
-
-func (s *Server) debugPacket(subsystem string, layer int, packet []byte) {
-	if s.Debug == nil {
-		return
-	}
-	s.Debug(subsystem, fmt.Sprintf("PKT %d %s END", layer, base64.StdEncoding.EncodeToString(packet)))
 }

--- a/tftp/tftp.go
+++ b/tftp/tftp.go
@@ -167,7 +167,10 @@ func (s *Server) transfer(addr net.Addr, req *rrq) error {
 
 	file, size, err := s.Handler(req.Filename, addr)
 	if err != nil {
-		conn.Write(tftpError("failed to get file"))
+		_, cerr := conn.Write(tftpError("failed to get file"))
+		if cerr != nil {
+			return fmt.Errorf("getting file bytes: %s, write err: %s", err, cerr)
+		}
 		return fmt.Errorf("getting file bytes: %s", err)
 	}
 	defer file.Close()


### PR DESCRIPTION
most of the current linter errors come from ignoring errors, one unused function, and missuses of make(map..)

