### PR TITLE
Add Fedora 33 to quickcmd.go

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -151,6 +151,7 @@ func fedoraRecipe(parent *cobra.Command) {
 		"30",
 		"31",
 		"32",
+		"33",
 	}
 
 	fedoraCmd := &cobra.Command{


### PR DESCRIPTION
Ref: https://docs.fedoraproject.org/en-US/fedora/f33/release-notes/