### PR TITLE
Add Debian Buster to quickcmd.go

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -41,6 +41,7 @@ func debianRecipe(parent *cobra.Command) {
 		"wheezy",
 		"jessie",
 		"stretch",
+		"buster",
 		"sid",
 	}
 


### PR DESCRIPTION
Ref: https://www.debian.org/releases/buster/