### PR TITLE
Update quickcmd.go

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -331,7 +331,7 @@ version defaults to latest, can also be a YYYY.MM.DD iso release version`,
 
 			httpSrv := fmt.Sprintf("%s/iso/%s", mirror, version)
 			kernel := fmt.Sprintf("%s/arch/boot/%s/vmlinuz-linux", httpSrv, arch)
-			initrd := fmt.Sprintf("%s/arch/boot/%s/archiso.img", httpSrv, arch)
+			initrd := fmt.Sprintf("%s/arch/boot/%s/initramfs-linux.img", httpSrv, arch)
 			cmdline := fmt.Sprintf("archisobasedir=arch archiso_http_srv=%s/ ip=dhcp verify=y net.ifnames=0", httpSrv)
 
 			fmt.Println(staticFromFlags(cmd, kernel, []string{initrd}, cmdline).Serve())


### PR DESCRIPTION
Updated to use the new filename for the `quick arch` command.