### PR TITLE
Fix archlinux quickcmd

### DIFF
--- a/pixiecore/cli/quickcmd.go
+++ b/pixiecore/cli/quickcmd.go
@@ -332,7 +332,7 @@ version defaults to latest, can also be a YYYY.MM.DD iso release version`,
 			httpSrv := fmt.Sprintf("%s/iso/%s", mirror, version)
 			kernel := fmt.Sprintf("%s/arch/boot/%s/vmlinuz-linux", httpSrv, arch)
 			initrd := fmt.Sprintf("%s/arch/boot/%s/initramfs-linux.img", httpSrv, arch)
-			cmdline := fmt.Sprintf("archisobasedir=arch archiso_http_srv=%s/ ip=dhcp verify=y net.ifnames=0", httpSrv)
+			cmdline := fmt.Sprintf("archisobasedir=arch archiso_http_srv=%s/ ip=dhcp cms_verify=y net.ifnames=0", httpSrv)
 
 			fmt.Println(staticFromFlags(cmd, kernel, []string{initrd}, cmdline).Serve())
 		},


### PR DESCRIPTION
The `verify=y` cmdline argument has been deprecated by https://gitlab.archlinux.org/archlinux/archiso/-/commit/dedfe0364cd665a12bb7a4d6fdb3b978d02026ab.

 This PR replaces it by `cms_verify=y`.